### PR TITLE
feat(auth): create authentication pages in Next.js app router

### DIFF
--- a/apps/nextjs/src/app/auth/callback/route.ts
+++ b/apps/nextjs/src/app/auth/callback/route.ts
@@ -1,0 +1,23 @@
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
+
+import { createClient } from "~/supabase/server";
+
+export async function GET(request: NextRequest) {
+  const requestUrl = new URL(request.url);
+  const code = requestUrl.searchParams.get("code");
+  const next = requestUrl.searchParams.get("next") ?? "/";
+  const origin = requestUrl.origin;
+
+  if (code) {
+    const supabase = await createClient();
+    const { error } = await supabase.auth.exchangeCodeForSession(code);
+
+    if (!error) {
+      return NextResponse.redirect(`${origin}${next}`);
+    }
+  }
+
+  // Return the user to an error page with some instructions
+  return NextResponse.redirect(`${origin}/auth/error`);
+}

--- a/apps/nextjs/src/app/auth/layout.tsx
+++ b/apps/nextjs/src/app/auth/layout.tsx
@@ -1,0 +1,11 @@
+export default function AuthLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="container flex min-h-screen items-center justify-center py-8">
+      <div className="w-full max-w-md">{children}</div>
+    </div>
+  );
+}

--- a/apps/nextjs/src/app/auth/layout.tsx
+++ b/apps/nextjs/src/app/auth/layout.tsx
@@ -4,8 +4,40 @@ export default function AuthLayout({
   children: React.ReactNode;
 }) {
   return (
-    <div className="container flex min-h-screen items-center justify-center py-8">
-      <div className="w-full max-w-md">{children}</div>
+    <div className="container relative grid min-h-screen flex-col items-center justify-center lg:max-w-none lg:grid-cols-2 lg:px-0">
+      <div className="relative hidden h-full flex-col bg-muted p-10 text-white dark:border-r lg:flex">
+        <div className="absolute inset-0 bg-zinc-900" />
+        <div className="relative z-20 flex items-center text-lg font-medium">
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            className="mr-2 h-6 w-6"
+          >
+            <path d="M15 6v12a3 3 0 1 0 3-3H6a3 3 0 1 0 3 3V6a3 3 0 1 0-3 3h12a3 3 0 1 0-3-3" />
+          </svg>
+          Goat
+        </div>
+        <div className="relative z-20 mt-auto">
+          <blockquote className="space-y-2">
+            <p className="text-lg">
+              &ldquo;Goat has transformed how I manage my tasks and time. The
+              intelligent scheduling and seamless integrations have made me
+              significantly more productive.&rdquo;
+            </p>
+            <footer className="text-sm">Sofia Davis</footer>
+          </blockquote>
+        </div>
+      </div>
+      <div className="lg:p-8">
+        <div className="mx-auto flex w-full flex-col justify-center space-y-6 sm:w-[350px]">
+          {children}
+        </div>
+      </div>
     </div>
   );
 }

--- a/apps/nextjs/src/app/auth/layout.tsx
+++ b/apps/nextjs/src/app/auth/layout.tsx
@@ -1,3 +1,5 @@
+import Link from "next/link";
+
 export default function AuthLayout({
   children,
 }: {
@@ -9,16 +11,32 @@ export default function AuthLayout({
         <div className="absolute inset-0 bg-zinc-900" />
         <div className="relative z-20 flex items-center text-lg font-medium">
           <svg
-            xmlns="http://www.w3.org/2000/svg"
+            className="mr-2 h-6 w-6"
             viewBox="0 0 24 24"
             fill="none"
-            stroke="currentColor"
-            strokeWidth="2"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            className="mr-2 h-6 w-6"
+            xmlns="http://www.w3.org/2000/svg"
           >
-            <path d="M15 6v12a3 3 0 1 0 3-3H6a3 3 0 1 0 3 3V6a3 3 0 1 0-3 3h12a3 3 0 1 0-3-3" />
+            <path
+              d="M12 2L2 7L12 12L22 7L12 2Z"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+            <path
+              d="M2 17L12 22L22 17"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+            <path
+              d="M2 12L12 17L22 12"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
           </svg>
           Goat
         </div>
@@ -35,6 +53,14 @@ export default function AuthLayout({
       </div>
       <div className="lg:p-8">
         <div className="mx-auto flex w-full flex-col justify-center space-y-6 sm:w-[350px]">
+          <div className="absolute right-4 top-4 md:right-8 md:top-8">
+            <Link
+              href="/"
+              className="inline-flex h-8 items-center justify-center rounded-md px-3 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50"
+            >
+              Home
+            </Link>
+          </div>
           {children}
         </div>
       </div>

--- a/apps/nextjs/src/app/auth/login/login-form-wrapper.tsx
+++ b/apps/nextjs/src/app/auth/login/login-form-wrapper.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Link from "next/link";
 import { useRouter } from "next/navigation";
 
 import { LoginForm } from "@goat/ui";
@@ -59,12 +60,17 @@ export function LoginFormWrapper() {
   };
 
   return (
-    <LoginForm
-      onSubmit={handleSubmit}
-      onGoogleSignIn={handleGoogleSignIn}
-      onFacebookSignIn={handleFacebookSignIn}
-      onForgotPassword={handleForgotPassword}
-      onSignUpClick={handleSignUpClick}
-    />
+    <>
+      <Link href="/" className="absolute right-4 top-4 md:right-8 md:top-8">
+        ← Back
+      </Link>
+      <LoginForm
+        onSubmit={handleSubmit}
+        onGoogleSignIn={handleGoogleSignIn}
+        onFacebookSignIn={handleFacebookSignIn}
+        onForgotPassword={handleForgotPassword}
+        onSignUpClick={handleSignUpClick}
+      />
+    </>
   );
 }

--- a/apps/nextjs/src/app/auth/login/login-form-wrapper.tsx
+++ b/apps/nextjs/src/app/auth/login/login-form-wrapper.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+
+import { LoginForm } from "@goat/ui";
+
+import { createClient } from "~/supabase/client";
+
+export function LoginFormWrapper() {
+  const router = useRouter();
+  const supabase = createClient();
+
+  const handleSubmit = async (values: { email: string; password: string }) => {
+    const { error } = await supabase.auth.signInWithPassword({
+      email: values.email,
+      password: values.password,
+    });
+
+    if (error) {
+      throw error;
+    }
+
+    router.refresh();
+    router.push("/");
+  };
+
+  const handleGoogleSignIn = async () => {
+    const { error } = await supabase.auth.signInWithOAuth({
+      provider: "google",
+      options: {
+        redirectTo: `${window.location.origin}/auth/callback`,
+      },
+    });
+
+    if (error) {
+      throw error;
+    }
+  };
+
+  const handleFacebookSignIn = async () => {
+    const { error } = await supabase.auth.signInWithOAuth({
+      provider: "facebook",
+      options: {
+        redirectTo: `${window.location.origin}/auth/callback`,
+      },
+    });
+
+    if (error) {
+      throw error;
+    }
+  };
+
+  const handleForgotPassword = () => {
+    router.push("/auth/reset-password");
+  };
+
+  const handleSignUpClick = () => {
+    router.push("/auth/signup");
+  };
+
+  return (
+    <LoginForm
+      onSubmit={handleSubmit}
+      onGoogleSignIn={handleGoogleSignIn}
+      onFacebookSignIn={handleFacebookSignIn}
+      onForgotPassword={handleForgotPassword}
+      onSignUpClick={handleSignUpClick}
+    />
+  );
+}

--- a/apps/nextjs/src/app/auth/login/login-form-wrapper.tsx
+++ b/apps/nextjs/src/app/auth/login/login-form-wrapper.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import Link from "next/link";
 import { useRouter } from "next/navigation";
 
 import { LoginForm } from "@goat/ui";
@@ -61,9 +60,6 @@ export function LoginFormWrapper() {
 
   return (
     <>
-      <Link href="/" className="absolute right-4 top-4 md:right-8 md:top-8">
-        ← Back
-      </Link>
       <LoginForm
         onSubmit={handleSubmit}
         onGoogleSignIn={handleGoogleSignIn}

--- a/apps/nextjs/src/app/auth/login/page.tsx
+++ b/apps/nextjs/src/app/auth/login/page.tsx
@@ -1,0 +1,17 @@
+import { redirect } from "next/navigation";
+
+import { createClient } from "~/supabase/server";
+import { LoginFormWrapper } from "./login-form-wrapper";
+
+export default async function LoginPage() {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (user) {
+    redirect("/");
+  }
+
+  return <LoginFormWrapper />;
+}

--- a/apps/nextjs/src/app/auth/reset-password/page.tsx
+++ b/apps/nextjs/src/app/auth/reset-password/page.tsx
@@ -1,0 +1,17 @@
+import { redirect } from "next/navigation";
+
+import { createClient } from "~/supabase/server";
+import { PasswordResetFormWrapper } from "./password-reset-form-wrapper";
+
+export default async function ResetPasswordPage() {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (user) {
+    redirect("/");
+  }
+
+  return <PasswordResetFormWrapper />;
+}

--- a/apps/nextjs/src/app/auth/reset-password/password-reset-form-wrapper.tsx
+++ b/apps/nextjs/src/app/auth/reset-password/password-reset-form-wrapper.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+
+import { PasswordResetForm } from "@goat/ui";
+
+import { createClient } from "~/supabase/client";
+
+export function PasswordResetFormWrapper() {
+  const router = useRouter();
+  const supabase = createClient();
+
+  const handleSubmit = async (values: { email: string }) => {
+    const { error } = await supabase.auth.resetPasswordForEmail(values.email, {
+      redirectTo: `${window.location.origin}/auth/callback?next=/auth/update-password`,
+    });
+
+    if (error) {
+      throw error;
+    }
+  };
+
+  const handleBackToSignIn = () => {
+    router.push("/auth/login");
+  };
+
+  return (
+    <PasswordResetForm
+      onSubmit={handleSubmit}
+      onBackToSignIn={handleBackToSignIn}
+    />
+  );
+}

--- a/apps/nextjs/src/app/auth/signup/page.tsx
+++ b/apps/nextjs/src/app/auth/signup/page.tsx
@@ -1,0 +1,17 @@
+import { redirect } from "next/navigation";
+
+import { createClient } from "~/supabase/server";
+import { SignupFormWrapper } from "./signup-form-wrapper";
+
+export default async function SignupPage() {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (user) {
+    redirect("/");
+  }
+
+  return <SignupFormWrapper />;
+}

--- a/apps/nextjs/src/app/auth/signup/signup-form-wrapper.tsx
+++ b/apps/nextjs/src/app/auth/signup/signup-form-wrapper.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+
+import { SignupForm } from "@goat/ui";
+
+import { createClient } from "~/supabase/client";
+
+export function SignupFormWrapper() {
+  const router = useRouter();
+  const supabase = createClient();
+
+  const handleSubmit = async (values: { email: string; password: string }) => {
+    const { error } = await supabase.auth.signUp({
+      email: values.email,
+      password: values.password,
+      options: {
+        emailRedirectTo: `${window.location.origin}/auth/callback`,
+      },
+    });
+
+    if (error) {
+      throw error;
+    }
+
+    router.refresh();
+    router.push("/");
+  };
+
+  const handleGoogleSignIn = async () => {
+    const { error } = await supabase.auth.signInWithOAuth({
+      provider: "google",
+      options: {
+        redirectTo: `${window.location.origin}/auth/callback`,
+      },
+    });
+
+    if (error) {
+      throw error;
+    }
+  };
+
+  const handleFacebookSignIn = async () => {
+    const { error } = await supabase.auth.signInWithOAuth({
+      provider: "facebook",
+      options: {
+        redirectTo: `${window.location.origin}/auth/callback`,
+      },
+    });
+
+    if (error) {
+      throw error;
+    }
+  };
+
+  const handleSignInClick = () => {
+    router.push("/auth/login");
+  };
+
+  return (
+    <SignupForm
+      onSubmit={handleSubmit}
+      onGoogleSignIn={handleGoogleSignIn}
+      onFacebookSignIn={handleFacebookSignIn}
+      onSignInClick={handleSignInClick}
+    />
+  );
+}

--- a/apps/nextjs/src/app/globals.css
+++ b/apps/nextjs/src/app/globals.css
@@ -10,8 +10,8 @@
     --card-foreground: 240 10% 3.9%;
     --popover: 0 0% 100%;
     --popover-foreground: 240 10% 3.9%;
-    --primary: 327 66% 69%;
-    --primary-foreground: 337 65.5% 17.1%;
+    --primary: 217 91% 60%;
+    --primary-foreground: 210 40% 98%;
     --secondary: 240 4.8% 95.9%;
     --secondary-foreground: 240 5.9% 10%;
     --muted: 240 4.8% 95.9%;
@@ -33,8 +33,8 @@
     --card-foreground: 0 0% 98%;
     --popover: 240 10% 3.9%;
     --popover-foreground: 0 0% 98%;
-    --primary: 327 66% 69%;
-    --primary-foreground: 337 65.5% 17.1%;
+    --primary: 217 91% 60%;
+    --primary-foreground: 210 40% 98%;
     --secondary: 240 3.7% 15.9%;
     --secondary-foreground: 0 0% 98%;
     --muted: 240 3.7% 15.9%;

--- a/packages/ui/components.json
+++ b/packages/ui/components.json
@@ -6,7 +6,7 @@
   "tailwind": {
     "config": "../../tooling/tailwind/web.ts",
     "css": "unused.css",
-    "baseColor": "zinc",
+    "baseColor": "black",
     "cssVariables": true
   },
   "aliases": {

--- a/packages/ui/src/auth/login-form.tsx
+++ b/packages/ui/src/auth/login-form.tsx
@@ -16,6 +16,7 @@ import {
   FormMessage,
   useForm,
 } from "../form";
+import { FacebookIcon, GoogleIcon, SpinnerIcon } from "../icons";
 import { Input } from "../input";
 
 const loginSchema = z.object({
@@ -90,10 +91,12 @@ export const LoginForm: FC<LoginFormProps> = ({
 
   return (
     <div className={cn("space-y-6", className)}>
-      <div className="space-y-2 text-center">
-        <h1 className="text-2xl font-semibold tracking-tight">Welcome back</h1>
+      <div className="flex flex-col space-y-2 text-center">
+        <h1 className="text-2xl font-semibold tracking-tight">
+          Sign in to your account
+        </h1>
         <p className="text-sm text-muted-foreground">
-          Enter your email to sign in to your account
+          Enter your email below to sign in to your account
         </p>
       </div>
 
@@ -161,6 +164,7 @@ export const LoginForm: FC<LoginFormProps> = ({
             className="w-full"
             disabled={isLoading || oauthLoading !== null}
           >
+            {isLoading && <SpinnerIcon className="mr-2 h-4 w-4 animate-spin" />}
             {isLoading ? "Signing in..." : "Sign in"}
           </Button>
         </form>
@@ -185,24 +189,13 @@ export const LoginForm: FC<LoginFormProps> = ({
             disabled={isLoading || oauthLoading !== null}
           >
             {oauthLoading === "google" ? (
-              "Loading..."
+              <>
+                <SpinnerIcon className="mr-2 h-4 w-4 animate-spin" />
+                Loading...
+              </>
             ) : (
               <>
-                <svg
-                  className="mr-2 h-4 w-4"
-                  aria-hidden="true"
-                  focusable="false"
-                  data-prefix="fab"
-                  data-icon="google"
-                  role="img"
-                  xmlns="http://www.w3.org/2000/svg"
-                  viewBox="0 0 488 512"
-                >
-                  <path
-                    fill="currentColor"
-                    d="M488 261.8C488 403.3 391.1 504 248 504 110.8 504 0 393.2 0 256S110.8 8 248 8c66.8 0 123 24.5 166.3 64.9l-67.5 64.9C258.5 52.6 94.3 116.6 94.3 256c0 86.5 69.1 156.6 153.7 156.6 98.2 0 135-70.4 140.8-106.9H248v-85.3h236.1c2.3 12.7 3.9 24.9 3.9 41.4z"
-                  />
-                </svg>
+                <GoogleIcon className="mr-2 h-4 w-4" />
                 Google
               </>
             )}
@@ -216,24 +209,13 @@ export const LoginForm: FC<LoginFormProps> = ({
             disabled={isLoading || oauthLoading !== null}
           >
             {oauthLoading === "facebook" ? (
-              "Loading..."
+              <>
+                <SpinnerIcon className="mr-2 h-4 w-4 animate-spin" />
+                Loading...
+              </>
             ) : (
               <>
-                <svg
-                  className="mr-2 h-4 w-4"
-                  aria-hidden="true"
-                  focusable="false"
-                  data-prefix="fab"
-                  data-icon="facebook"
-                  role="img"
-                  xmlns="http://www.w3.org/2000/svg"
-                  viewBox="0 0 320 512"
-                >
-                  <path
-                    fill="currentColor"
-                    d="M80 299.3V512H196V299.3h86.5l18-97.8H196V166.9c0-51.7 20.3-71.5 72.7-71.5c16.3 0 29.4.4 37 1.2V7.9C291.4 4 256.4 0 236.2 0C129.3 0 80 50.5 80 159.4v42.1H14v97.8H80z"
-                  />
-                </svg>
+                <FacebookIcon className="mr-2 h-4 w-4" />
                 Facebook
               </>
             )}

--- a/packages/ui/src/auth/password-reset-form.tsx
+++ b/packages/ui/src/auth/password-reset-form.tsx
@@ -16,6 +16,7 @@ import {
   FormMessage,
   useForm,
 } from "../form";
+import { SpinnerIcon } from "../icons";
 import { Input } from "../input";
 
 const passwordResetSchema = z.object({
@@ -66,7 +67,7 @@ export const PasswordResetForm: FC<PasswordResetFormProps> = ({
   if (isSuccess) {
     return (
       <div className={cn("space-y-6", className)}>
-        <div className="space-y-2 text-center">
+        <div className="flex flex-col space-y-2 text-center">
           <div className="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-primary/10">
             <svg
               className="h-6 w-6 text-primary"
@@ -122,7 +123,7 @@ export const PasswordResetForm: FC<PasswordResetFormProps> = ({
 
   return (
     <div className={cn("space-y-6", className)}>
-      <div className="space-y-2 text-center">
+      <div className="flex flex-col space-y-2 text-center">
         <h1 className="text-2xl font-semibold tracking-tight">
           Forgot your password?
         </h1>
@@ -161,6 +162,7 @@ export const PasswordResetForm: FC<PasswordResetFormProps> = ({
           )}
 
           <Button type="submit" className="w-full" disabled={isLoading}>
+            {isLoading && <SpinnerIcon className="mr-2 h-4 w-4 animate-spin" />}
             {isLoading ? "Sending..." : "Send reset email"}
           </Button>
         </form>

--- a/packages/ui/src/auth/signup-form.tsx
+++ b/packages/ui/src/auth/signup-form.tsx
@@ -16,6 +16,7 @@ import {
   FormMessage,
   useForm,
 } from "../form";
+import { FacebookIcon, GoogleIcon, SpinnerIcon } from "../icons";
 import { Input } from "../input";
 
 const signupSchema = z
@@ -100,7 +101,7 @@ export const SignupForm: FC<SignupFormProps> = ({
 
   return (
     <div className={cn("space-y-6", className)}>
-      <div className="space-y-2 text-center">
+      <div className="flex flex-col space-y-2 text-center">
         <h1 className="text-2xl font-semibold tracking-tight">
           Create an account
         </h1>
@@ -181,7 +182,8 @@ export const SignupForm: FC<SignupFormProps> = ({
             className="w-full"
             disabled={isLoading || oauthLoading !== null}
           >
-            {isLoading ? "Creating account..." : "Sign up"}
+            {isLoading && <SpinnerIcon className="mr-2 h-4 w-4 animate-spin" />}
+            {isLoading ? "Creating account..." : "Create account"}
           </Button>
         </form>
       </Form>
@@ -205,24 +207,13 @@ export const SignupForm: FC<SignupFormProps> = ({
             disabled={isLoading || oauthLoading !== null}
           >
             {oauthLoading === "google" ? (
-              "Loading..."
+              <>
+                <SpinnerIcon className="mr-2 h-4 w-4 animate-spin" />
+                Loading...
+              </>
             ) : (
               <>
-                <svg
-                  className="mr-2 h-4 w-4"
-                  aria-hidden="true"
-                  focusable="false"
-                  data-prefix="fab"
-                  data-icon="google"
-                  role="img"
-                  xmlns="http://www.w3.org/2000/svg"
-                  viewBox="0 0 488 512"
-                >
-                  <path
-                    fill="currentColor"
-                    d="M488 261.8C488 403.3 391.1 504 248 504 110.8 504 0 393.2 0 256S110.8 8 248 8c66.8 0 123 24.5 166.3 64.9l-67.5 64.9C258.5 52.6 94.3 116.6 94.3 256c0 86.5 69.1 156.6 153.7 156.6 98.2 0 135-70.4 140.8-106.9H248v-85.3h236.1c2.3 12.7 3.9 24.9 3.9 41.4z"
-                  />
-                </svg>
+                <GoogleIcon className="mr-2 h-4 w-4" />
                 Google
               </>
             )}
@@ -236,24 +227,13 @@ export const SignupForm: FC<SignupFormProps> = ({
             disabled={isLoading || oauthLoading !== null}
           >
             {oauthLoading === "facebook" ? (
-              "Loading..."
+              <>
+                <SpinnerIcon className="mr-2 h-4 w-4 animate-spin" />
+                Loading...
+              </>
             ) : (
               <>
-                <svg
-                  className="mr-2 h-4 w-4"
-                  aria-hidden="true"
-                  focusable="false"
-                  data-prefix="fab"
-                  data-icon="facebook"
-                  role="img"
-                  xmlns="http://www.w3.org/2000/svg"
-                  viewBox="0 0 320 512"
-                >
-                  <path
-                    fill="currentColor"
-                    d="M80 299.3V512H196V299.3h86.5l18-97.8H196V166.9c0-51.7 20.3-71.5 72.7-71.5c16.3 0 29.4.4 37 1.2V7.9C291.4 4 256.4 0 236.2 0C129.3 0 80 50.5 80 159.4v42.1H14v97.8H80z"
-                  />
-                </svg>
+                <FacebookIcon className="mr-2 h-4 w-4" />
                 Facebook
               </>
             )}

--- a/packages/ui/src/icons.tsx
+++ b/packages/ui/src/icons.tsx
@@ -1,0 +1,72 @@
+import type { SVGProps } from "react";
+
+export function GoogleIcon(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg
+      aria-hidden="true"
+      focusable="false"
+      data-prefix="fab"
+      data-icon="google"
+      role="img"
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      {...props}
+    >
+      <path
+        fill="currentColor"
+        d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"
+      />
+      <path
+        fill="currentColor"
+        d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
+      />
+      <path
+        fill="currentColor"
+        d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"
+      />
+      <path
+        fill="currentColor"
+        d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
+      />
+    </svg>
+  );
+}
+
+export function FacebookIcon(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg
+      aria-hidden="true"
+      focusable="false"
+      data-prefix="fab"
+      data-icon="facebook"
+      role="img"
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      {...props}
+    >
+      <path
+        fill="currentColor"
+        d="M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99 4.388 10.954 10.125 11.854v-8.385H7.078v-3.47h3.047V9.43c0-3.007 1.792-4.669 4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.874v2.25h3.328l-.532 3.47h-2.796v8.385C19.612 23.027 24 18.062 24 12.073z"
+      />
+    </svg>
+  );
+}
+
+export function SpinnerIcon(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      {...props}
+    >
+      <path d="M21 12a9 9 0 1 1-6.219-8.56" />
+    </svg>
+  );
+}

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -7,3 +7,6 @@ export { cn };
 
 // Export auth components
 export * from "./auth";
+
+// Export icons
+export * from "./icons";


### PR DESCRIPTION
## Summary
- Created login, signup, and password reset pages with Supabase authentication
- Implemented OAuth callback route for Google/Facebook authentication  
- Added shared auth layout for consistent page structure

## Implementation Details
- **Login page**: Email/password authentication with OAuth options (Google, Facebook)
- **Signup page**: Account creation with password confirmation
- **Password reset page**: Email-based password recovery flow
- **OAuth callback**: Handles authentication callbacks and token exchange
- **Auth layout**: Centralized layout for all auth pages with responsive design

## Test plan
- [ ] Visit `/auth/login` - should see login form with email/password fields
- [ ] Visit `/auth/signup` - should see signup form with password confirmation
- [ ] Visit `/auth/reset-password` - should see password reset form
- [ ] Test OAuth login/signup buttons (requires OAuth configuration in Supabase)
- [ ] Verify authenticated users are redirected from auth pages to home page
- [ ] Test form validation and error handling

🤖 Generated with [Claude Code](https://claude.ai/code)