### PR TITLE
feat(auth): implement auth API handlers for form submissions

### DIFF
--- a/apps/nextjs/src/app/auth/actions.ts
+++ b/apps/nextjs/src/app/auth/actions.ts
@@ -1,0 +1,190 @@
+"use server";
+
+import { headers } from "next/headers";
+import { redirect } from "next/navigation";
+
+import type {
+  ResetPasswordInput,
+  SignInInput,
+  SignUpInput,
+} from "@goat/validators";
+import {
+  resetPasswordSchema,
+  signInSchema,
+  signUpSchema,
+} from "@goat/validators";
+
+import { createClient } from "~/supabase/server";
+
+async function getOrigin() {
+  const headersList = await headers();
+  const host = headersList.get("host") ?? "localhost:3000";
+  const protocol = host.includes("localhost") ? "http" : "https";
+  return `${protocol}://${host}`;
+}
+
+export async function signIn(input: SignInInput) {
+  // Validate input
+  const validatedInput = signInSchema.safeParse(input);
+  if (!validatedInput.success) {
+    return {
+      error: validatedInput.error.flatten().fieldErrors,
+    };
+  }
+
+  const supabase = await createClient();
+
+  const { error } = await supabase.auth.signInWithPassword({
+    email: validatedInput.data.email,
+    password: validatedInput.data.password,
+  });
+
+  if (error) {
+    if (error.message === "Invalid login credentials") {
+      return {
+        error: {
+          email: ["Invalid email or password"],
+          password: ["Invalid email or password"],
+        },
+      };
+    }
+
+    // Handle other errors
+    return {
+      error: {
+        email: [error.message],
+      },
+    };
+  }
+
+  // Redirect to dashboard on success
+  redirect("/dashboard");
+}
+
+export async function signUp(input: SignUpInput) {
+  // Validate input
+  const validatedInput = signUpSchema.safeParse(input);
+  if (!validatedInput.success) {
+    return {
+      error: validatedInput.error.flatten().fieldErrors,
+    };
+  }
+
+  const supabase = await createClient();
+
+  const { error } = await supabase.auth.signUp({
+    email: validatedInput.data.email,
+    password: validatedInput.data.password,
+  });
+
+  if (error) {
+    if (error.message.includes("already registered")) {
+      return {
+        error: {
+          email: ["This email is already registered"],
+        },
+      };
+    }
+
+    // Handle other errors
+    return {
+      error: {
+        email: [error.message],
+      },
+    };
+  }
+
+  // Redirect to verification pending page or dashboard
+  redirect("/auth/verify-email");
+}
+
+export async function resetPassword(input: ResetPasswordInput) {
+  // Validate input
+  const validatedInput = resetPasswordSchema.safeParse(input);
+  if (!validatedInput.success) {
+    return {
+      error: validatedInput.error.flatten().fieldErrors,
+    };
+  }
+
+  const supabase = await createClient();
+  const origin = await getOrigin();
+
+  const { error } = await supabase.auth.resetPasswordForEmail(
+    validatedInput.data.email,
+    {
+      redirectTo: `${origin}/auth/reset-password`,
+    },
+  );
+
+  if (error) {
+    return {
+      error: {
+        email: [error.message],
+      },
+    };
+  }
+
+  // Return success message
+  return {
+    success: "Check your email for a password reset link",
+  };
+}
+
+export async function signInWithGoogle() {
+  const supabase = await createClient();
+  const origin = await getOrigin();
+
+  const { data, error } = await supabase.auth.signInWithOAuth({
+    provider: "google",
+    options: {
+      redirectTo: `${origin}/auth/callback`,
+    },
+  });
+
+  if (error) {
+    return {
+      error: error.message,
+    };
+  }
+
+  if (data.url) {
+    redirect(data.url);
+  }
+}
+
+export async function signInWithFacebook() {
+  const supabase = await createClient();
+  const origin = await getOrigin();
+
+  const { data, error } = await supabase.auth.signInWithOAuth({
+    provider: "facebook",
+    options: {
+      redirectTo: `${origin}/auth/callback`,
+    },
+  });
+
+  if (error) {
+    return {
+      error: error.message,
+    };
+  }
+
+  if (data.url) {
+    redirect(data.url);
+  }
+}
+
+export async function signOut() {
+  const supabase = await createClient();
+
+  const { error } = await supabase.auth.signOut();
+
+  if (error) {
+    return {
+      error: error.message,
+    };
+  }
+
+  redirect("/");
+}

--- a/apps/nextjs/src/app/auth/callback/route.ts
+++ b/apps/nextjs/src/app/auth/callback/route.ts
@@ -1,0 +1,20 @@
+import { NextResponse } from "next/server";
+
+import { createClient } from "~/supabase/server";
+
+export async function GET(request: Request) {
+  const { searchParams, origin } = new URL(request.url);
+  const code = searchParams.get("code");
+  const next = searchParams.get("next") ?? "/dashboard";
+
+  if (code) {
+    const supabase = await createClient();
+    const { error } = await supabase.auth.exchangeCodeForSession(code);
+    if (!error) {
+      return NextResponse.redirect(`${origin}${next}`);
+    }
+  }
+
+  // Return the user to an error page with instructions
+  return NextResponse.redirect(`${origin}/auth/auth-error`);
+}

--- a/packages/validators/src/index.ts
+++ b/packages/validators/src/index.ts
@@ -1,8 +1,20 @@
 import { z } from "zod/v4";
 
-export const unused = z.string().describe(
-  `This lib is currently not used as we use drizzle-zod for simple schemas
-   But as your application grows and you need other validators to share
-   with back and frontend, you can put them in here
-  `,
-);
+// Auth validation schemas
+export const signInSchema = z.object({
+  email: z.string().email("Invalid email address"),
+  password: z.string().min(8, "Password must be at least 8 characters"),
+});
+
+export const signUpSchema = z.object({
+  email: z.string().email("Invalid email address"),
+  password: z.string().min(8, "Password must be at least 8 characters"),
+});
+
+export const resetPasswordSchema = z.object({
+  email: z.string().email("Invalid email address"),
+});
+
+export type SignInInput = z.infer<typeof signInSchema>;
+export type SignUpInput = z.infer<typeof signUpSchema>;
+export type ResetPasswordInput = z.infer<typeof resetPasswordSchema>;


### PR DESCRIPTION
## Summary
- Implemented server actions for authentication (signIn, signUp, resetPassword)
- Added OAuth handlers for Google and Facebook authentication
- Created auth callback route for OAuth flow
- Added Zod validation schemas for auth forms

## Implementation Details
This PR implements Task #8 from the auth feature spec, creating the necessary server actions to handle authentication form submissions. The implementation follows the existing patterns in the codebase and integrates with the Supabase authentication system.

### Key Changes:
1. **Server Actions** (`apps/nextjs/src/app/auth/actions.ts`):
   - `signIn`: Handles email/password login with validation
   - `signUp`: Handles user registration with validation
   - `resetPassword`: Handles password reset requests
   - `signInWithGoogle`: OAuth handler for Google login
   - `signInWithFacebook`: OAuth handler for Facebook login
   - `signOut`: Handles user logout

2. **OAuth Callback** (`apps/nextjs/src/app/auth/callback/route.ts`):
   - Handles OAuth callback flow
   - Exchanges authorization code for session
   - Redirects to appropriate page after authentication

3. **Validation Schemas** (`packages/validators/src/index.ts`):
   - Added Zod schemas for auth forms
   - Type-safe input validation

## Test Plan
- [ ] Test email/password login with valid credentials
- [ ] Test email/password login with invalid credentials
- [ ] Test user registration with new email
- [ ] Test user registration with existing email
- [ ] Test password reset flow
- [ ] Test Google OAuth login
- [ ] Test Facebook OAuth login
- [ ] Test logout functionality
- [ ] Verify proper error handling and messages

🤖 Generated with [Claude Code](https://claude.ai/code)