### PR TITLE
feat(auth): implement server actions for auth form submissions

### DIFF
--- a/apps/nextjs/src/app/auth/actions.ts
+++ b/apps/nextjs/src/app/auth/actions.ts
@@ -1,0 +1,237 @@
+"use server";
+
+import { redirect } from "next/navigation";
+
+import {
+  resetPasswordSchema,
+  signInSchema,
+  signUpSchema,
+} from "@goat/validators";
+
+import { createClient } from "~/supabase/server";
+
+// Error type for consistent error handling
+export interface AuthActionError {
+  error: string;
+  field?: string;
+}
+
+export type AuthActionResponse<T = void> =
+  | { success: true; data?: T }
+  | { success: false; error: AuthActionError };
+
+/**
+ * Sign in with email and password
+ */
+export async function signIn(formData: FormData): Promise<AuthActionResponse> {
+  const rawData = {
+    email: formData.get("email") as string,
+    password: formData.get("password") as string,
+  };
+
+  // Validate input
+  const validationResult = signInSchema.safeParse(rawData);
+  if (!validationResult.success) {
+    const error = validationResult.error.issues[0];
+    return {
+      success: false,
+      error: {
+        error: error?.message ?? "Invalid input",
+        field: error?.path[0] as string | undefined,
+      },
+    };
+  }
+
+  const { email, password } = validationResult.data;
+
+  // Create Supabase client
+  const supabase = await createClient();
+
+  // Attempt to sign in
+  const { error } = await supabase.auth.signInWithPassword({
+    email,
+    password,
+  });
+
+  if (error) {
+    // Handle specific error cases
+    if (error.message === "Invalid login credentials") {
+      return {
+        success: false,
+        error: {
+          error: "Invalid email or password",
+        },
+      };
+    }
+
+    if (error.message === "Email not confirmed") {
+      return {
+        success: false,
+        error: {
+          error: "Please verify your email before signing in",
+        },
+      };
+    }
+
+    // Network or other errors
+    return {
+      success: false,
+      error: {
+        error: "An error occurred during sign in. Please try again.",
+      },
+    };
+  }
+
+  // Successful sign in - redirect to dashboard
+  redirect("/dashboard");
+}
+
+/**
+ * Sign up a new user
+ */
+export async function signUp(formData: FormData): Promise<AuthActionResponse> {
+  const rawData = {
+    email: formData.get("email") as string,
+    password: formData.get("password") as string,
+    confirmPassword: formData.get("confirmPassword") as string,
+  };
+
+  // Validate input
+  const validationResult = signUpSchema.safeParse(rawData);
+  if (!validationResult.success) {
+    const error = validationResult.error.issues[0];
+    return {
+      success: false,
+      error: {
+        error: error?.message ?? "Invalid input",
+        field: error?.path[0] as string | undefined,
+      },
+    };
+  }
+
+  const { email, password } = validationResult.data;
+
+  // Create Supabase client
+  const supabase = await createClient();
+
+  // Attempt to sign up
+  const { error } = await supabase.auth.signUp({
+    email,
+    password,
+  });
+
+  if (error) {
+    // Handle specific error cases
+    if (error.message === "User already registered") {
+      return {
+        success: false,
+        error: {
+          error: "An account with this email already exists",
+          field: "email",
+        },
+      };
+    }
+
+    if (error.message.includes("Password")) {
+      return {
+        success: false,
+        error: {
+          error: error.message,
+          field: "password",
+        },
+      };
+    }
+
+    // Network or other errors
+    return {
+      success: false,
+      error: {
+        error: "An error occurred during sign up. Please try again.",
+      },
+    };
+  }
+
+  // Successful sign up - redirect to verification page
+  redirect("/auth/verify-email?email=" + encodeURIComponent(email));
+}
+
+/**
+ * Request a password reset email
+ */
+export async function resetPassword(
+  formData: FormData,
+): Promise<AuthActionResponse> {
+  const rawData = {
+    email: formData.get("email") as string,
+  };
+
+  // Validate input
+  const validationResult = resetPasswordSchema.safeParse(rawData);
+  if (!validationResult.success) {
+    const error = validationResult.error.issues[0];
+    return {
+      success: false,
+      error: {
+        error: error?.message ?? "Invalid input",
+        field: error?.path[0] as string | undefined,
+      },
+    };
+  }
+
+  const { email } = validationResult.data;
+
+  // Create Supabase client
+  const supabase = await createClient();
+
+  // Request password reset
+  const { error } = await supabase.auth.resetPasswordForEmail(email);
+
+  if (error) {
+    // Don't reveal whether email exists for security
+    // Always show success message
+    return {
+      success: true,
+    };
+  }
+
+  // Always return success to prevent email enumeration
+  return {
+    success: true,
+  };
+}
+
+/**
+ * Sign in with OAuth provider (Google, Facebook, etc.)
+ */
+export async function signInWithOAuth(
+  provider: "google" | "facebook",
+): Promise<void> {
+  const supabase = await createClient();
+
+  const { data, error } = await supabase.auth.signInWithOAuth({
+    provider,
+  });
+
+  if (error) {
+    throw new Error(`OAuth sign in failed: ${error.message}`);
+  }
+
+  if (data.url) {
+    redirect(data.url);
+  }
+}
+
+/**
+ * Sign out the current user
+ */
+export async function signOut(): Promise<void> {
+  const supabase = await createClient();
+
+  const { error } = await supabase.auth.signOut();
+
+  if (error) {
+    throw new Error(`Sign out failed: ${error.message}`);
+  }
+
+  redirect("/");
+}

--- a/apps/nextjs/src/app/auth/callback/route.ts
+++ b/apps/nextjs/src/app/auth/callback/route.ts
@@ -1,0 +1,23 @@
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
+
+import { createClient } from "~/supabase/server";
+
+export async function GET(request: NextRequest) {
+  const requestUrl = new URL(request.url);
+  const code = requestUrl.searchParams.get("code");
+  const origin = requestUrl.origin;
+
+  if (code) {
+    const supabase = await createClient();
+    const { error } = await supabase.auth.exchangeCodeForSession(code);
+
+    if (!error) {
+      // Successful authentication, redirect to dashboard or home
+      return NextResponse.redirect(`${origin}/dashboard`);
+    }
+  }
+
+  // Authentication failed or no code provided
+  return NextResponse.redirect(`${origin}/auth/login?error=auth_failed`);
+}

--- a/apps/nextjs/src/app/auth/reset-password/page.tsx
+++ b/apps/nextjs/src/app/auth/reset-password/page.tsx
@@ -1,0 +1,23 @@
+import Link from "next/link";
+import { GalleryVerticalEnd } from "lucide-react";
+
+import { ResetPasswordForm } from "~/components/reset-password-form";
+
+export default function ResetPasswordPage() {
+  return (
+    <div className="bg-muted flex min-h-svh flex-col items-center justify-center gap-6 p-6 md:p-10">
+      <div className="flex w-full max-w-sm flex-col gap-6">
+        <Link
+          href="/"
+          className="flex items-center gap-2 self-center font-medium"
+        >
+          <div className="bg-primary text-primary-foreground flex size-6 items-center justify-center rounded-md">
+            <GalleryVerticalEnd className="size-4" />
+          </div>
+          Acme Inc.
+        </Link>
+        <ResetPasswordForm />
+      </div>
+    </div>
+  );
+}

--- a/apps/nextjs/src/app/auth/signup/page.tsx
+++ b/apps/nextjs/src/app/auth/signup/page.tsx
@@ -1,0 +1,23 @@
+import Link from "next/link";
+import { GalleryVerticalEnd } from "lucide-react";
+
+import { SignupForm } from "~/components/signup-form";
+
+export default function SignupPage() {
+  return (
+    <div className="bg-muted flex min-h-svh flex-col items-center justify-center gap-6 p-6 md:p-10">
+      <div className="flex w-full max-w-sm flex-col gap-6">
+        <Link
+          href="/"
+          className="flex items-center gap-2 self-center font-medium"
+        >
+          <div className="bg-primary text-primary-foreground flex size-6 items-center justify-center rounded-md">
+            <GalleryVerticalEnd className="size-4" />
+          </div>
+          Acme Inc.
+        </Link>
+        <SignupForm />
+      </div>
+    </div>
+  );
+}

--- a/apps/nextjs/src/app/auth/verify-email/page.tsx
+++ b/apps/nextjs/src/app/auth/verify-email/page.tsx
@@ -1,0 +1,84 @@
+import Link from "next/link";
+import { GalleryVerticalEnd } from "lucide-react";
+
+import { Button } from "@goat/ui/components/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@goat/ui/components/card";
+
+export default function VerifyEmailPage({
+  searchParams,
+}: {
+  searchParams: { email?: string };
+}) {
+  const email = searchParams.email;
+
+  return (
+    <div className="bg-muted flex min-h-svh flex-col items-center justify-center gap-6 p-6 md:p-10">
+      <div className="flex w-full max-w-sm flex-col gap-6">
+        <Link
+          href="/"
+          className="flex items-center gap-2 self-center font-medium"
+        >
+          <div className="bg-primary text-primary-foreground flex size-6 items-center justify-center rounded-md">
+            <GalleryVerticalEnd className="size-4" />
+          </div>
+          Acme Inc.
+        </Link>
+        <Card>
+          <CardHeader className="text-center">
+            <div className="mx-auto mb-4 flex size-12 items-center justify-center rounded-full bg-green-100 dark:bg-green-900/20">
+              <svg
+                className="size-6 text-green-600 dark:text-green-400"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"
+                />
+              </svg>
+            </div>
+            <CardTitle className="text-xl">Check your email</CardTitle>
+            <CardDescription>
+              We&apos;ve sent a verification link to{" "}
+              <span className="font-semibold">
+                {email ?? "your email address"}
+              </span>
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <p className="text-muted-foreground text-center text-sm">
+              Please check your inbox and click the verification link to
+              activate your account. The link will expire in 24 hours.
+            </p>
+            <div className="bg-muted rounded-md p-3">
+              <p className="text-sm">
+                <span className="font-medium">
+                  Didn&apos;t receive the email?
+                </span>
+              </p>
+              <ul className="text-muted-foreground mt-2 space-y-1 text-sm">
+                <li>• Check your spam or junk folder</li>
+                <li>• Make sure you entered the correct email</li>
+                <li>• Wait a few minutes and check again</li>
+              </ul>
+            </div>
+            <div className="flex flex-col gap-2">
+              <Button variant="outline" className="w-full" asChild>
+                <Link href="/auth/login">Back to login</Link>
+              </Button>
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+}

--- a/apps/nextjs/src/components/reset-password-form.tsx
+++ b/apps/nextjs/src/components/reset-password-form.tsx
@@ -1,0 +1,117 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import { useFormStatus } from "react-dom";
+
+import { Button } from "@goat/ui/components/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@goat/ui/components/card";
+import { Input } from "@goat/ui/components/input";
+import { Label } from "@goat/ui/components/label";
+import { cn } from "@goat/ui/lib/utils";
+
+import { resetPassword } from "~/app/auth/actions";
+
+function SubmitButton() {
+  const { pending } = useFormStatus();
+
+  return (
+    <Button type="submit" className="w-full" disabled={pending}>
+      {pending ? "Sending reset email..." : "Send reset email"}
+    </Button>
+  );
+}
+
+export function ResetPasswordForm({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState(false);
+
+  async function handleSubmit(formData: FormData) {
+    setError(null);
+    setSuccess(false);
+
+    const result = await resetPassword(formData);
+
+    if (result.success) {
+      setSuccess(true);
+    } else {
+      setError(result.error.error);
+    }
+  }
+
+  return (
+    <div className={cn("flex flex-col gap-6", className)} {...props}>
+      <Card>
+        <CardHeader className="text-center">
+          <CardTitle className="text-xl">Reset your password</CardTitle>
+          <CardDescription>
+            Enter your email address and we&apos;ll send you a link to reset
+            your password
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          {success ? (
+            <div className="space-y-4">
+              <div className="rounded-md bg-green-50 p-4 text-sm text-green-900 dark:bg-green-900/10 dark:text-green-100">
+                <p className="font-semibold">Check your email</p>
+                <p className="mt-1">
+                  If an account exists with that email, we&apos;ve sent you a
+                  password reset link. Please check your inbox and follow the
+                  instructions.
+                </p>
+              </div>
+              <div className="text-center text-sm">
+                <Link
+                  href="/auth/login"
+                  className="underline underline-offset-4"
+                >
+                  Back to login
+                </Link>
+              </div>
+            </div>
+          ) : (
+            <form action={handleSubmit}>
+              <div className="grid gap-6">
+                {error && (
+                  <div className="bg-destructive/10 text-destructive rounded-md p-3 text-sm">
+                    {error}
+                  </div>
+                )}
+                <div className="grid gap-3">
+                  <Label htmlFor="email">Email</Label>
+                  <Input
+                    id="email"
+                    name="email"
+                    type="email"
+                    placeholder="m@example.com"
+                    required
+                    autoComplete="email"
+                  />
+                </div>
+                <SubmitButton />
+                <div className="text-center text-sm">
+                  Remember your password?{" "}
+                  <Link
+                    href="/auth/login"
+                    className="underline underline-offset-4"
+                  >
+                    Sign in
+                  </Link>
+                </div>
+              </div>
+            </form>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/apps/nextjs/src/components/signup-form.tsx
+++ b/apps/nextjs/src/components/signup-form.tsx
@@ -16,30 +16,36 @@ import { Input } from "@goat/ui/components/input";
 import { Label } from "@goat/ui/components/label";
 import { cn } from "@goat/ui/lib/utils";
 
-import { signIn, signInWithOAuth } from "~/app/auth/actions";
+import { signInWithOAuth, signUp } from "~/app/auth/actions";
 
 function SubmitButton() {
   const { pending } = useFormStatus();
 
   return (
     <Button type="submit" className="w-full" disabled={pending}>
-      {pending ? "Signing in..." : "Login"}
+      {pending ? "Creating account..." : "Sign up"}
     </Button>
   );
 }
 
-export function LoginForm({
+export function SignupForm({
   className,
   ...props
 }: React.ComponentProps<"div">) {
   const [error, setError] = useState<string | null>(null);
+  const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({});
 
   async function handleSubmit(formData: FormData) {
     setError(null);
-    const result = await signIn(formData);
+    setFieldErrors({});
+    const result = await signUp(formData);
 
     if (!result.success) {
-      setError(result.error.error);
+      if (result.error.field) {
+        setFieldErrors({ [result.error.field]: result.error.error });
+      } else {
+        setError(result.error.error);
+      }
     }
   }
 
@@ -47,9 +53,9 @@ export function LoginForm({
     <div className={cn("flex flex-col gap-6", className)} {...props}>
       <Card>
         <CardHeader className="text-center">
-          <CardTitle className="text-xl">Welcome back</CardTitle>
+          <CardTitle className="text-xl">Create an account</CardTitle>
           <CardDescription>
-            Login with your email or social account
+            Sign up with your email or social account
           </CardDescription>
         </CardHeader>
         <CardContent>
@@ -72,7 +78,7 @@ export function LoginForm({
                     fill="currentColor"
                   />
                 </svg>
-                Login with Google
+                Sign up with Google
               </Button>
               <Button
                 variant="outline"
@@ -91,7 +97,7 @@ export function LoginForm({
                     fill="currentColor"
                   />
                 </svg>
-                Login with Facebook
+                Sign up with Facebook
               </Button>
             </div>
             <div className="after:border-border relative text-center text-sm after:absolute after:inset-0 after:top-1/2 after:z-0 after:flex after:items-center after:border-t">
@@ -114,35 +120,67 @@ export function LoginForm({
                     type="email"
                     placeholder="m@example.com"
                     required
+                    aria-invalid={!!fieldErrors.email}
+                    aria-describedby={
+                      fieldErrors.email ? "email-error" : undefined
+                    }
                   />
+                  {fieldErrors.email && (
+                    <p id="email-error" className="text-destructive text-sm">
+                      {fieldErrors.email}
+                    </p>
+                  )}
                 </div>
                 <div className="grid gap-3">
-                  <div className="flex items-center">
-                    <Label htmlFor="password">Password</Label>
-                    <Link
-                      href="/auth/reset-password"
-                      className="ml-auto text-sm underline-offset-4 hover:underline"
-                    >
-                      Forgot your password?
-                    </Link>
-                  </div>
+                  <Label htmlFor="password">Password</Label>
                   <Input
                     id="password"
                     name="password"
                     type="password"
                     required
+                    placeholder="At least 8 characters"
+                    aria-invalid={!!fieldErrors.password}
+                    aria-describedby={
+                      fieldErrors.password ? "password-error" : undefined
+                    }
                   />
+                  {fieldErrors.password && (
+                    <p id="password-error" className="text-destructive text-sm">
+                      {fieldErrors.password}
+                    </p>
+                  )}
+                </div>
+                <div className="grid gap-3">
+                  <Label htmlFor="confirmPassword">Confirm Password</Label>
+                  <Input
+                    id="confirmPassword"
+                    name="confirmPassword"
+                    type="password"
+                    required
+                    placeholder="Confirm your password"
+                    aria-invalid={!!fieldErrors.confirmPassword}
+                    aria-describedby={
+                      fieldErrors.confirmPassword
+                        ? "confirmPassword-error"
+                        : undefined
+                    }
+                  />
+                  {fieldErrors.confirmPassword && (
+                    <p
+                      id="confirmPassword-error"
+                      className="text-destructive text-sm"
+                    >
+                      {fieldErrors.confirmPassword}
+                    </p>
+                  )}
                 </div>
                 <SubmitButton />
               </div>
             </form>
             <div className="text-center text-sm">
-              Don&apos;t have an account?{" "}
-              <Link
-                href="/auth/signup"
-                className="underline underline-offset-4"
-              >
-                Sign up
+              Already have an account?{" "}
+              <Link href="/auth/login" className="underline underline-offset-4">
+                Sign in
               </Link>
             </div>
           </div>

--- a/packages/validators/src/auth.ts
+++ b/packages/validators/src/auth.ts
@@ -1,0 +1,41 @@
+import { z } from "zod/v4";
+
+// Sign In schema
+export const signInSchema = z.object({
+  email: z.string().email("Invalid email address"),
+  password: z.string().min(8, "Password must be at least 8 characters"),
+});
+
+// Sign Up schema
+export const signUpSchema = z
+  .object({
+    email: z.string().email("Invalid email address"),
+    password: z.string().min(8, "Password must be at least 8 characters"),
+    confirmPassword: z.string(),
+  })
+  .refine((data) => data.password === data.confirmPassword, {
+    message: "Passwords do not match",
+    path: ["confirmPassword"],
+  });
+
+// Reset Password schema
+export const resetPasswordSchema = z.object({
+  email: z.string().email("Invalid email address"),
+});
+
+// New Password schema (for password reset confirmation)
+export const newPasswordSchema = z
+  .object({
+    password: z.string().min(8, "Password must be at least 8 characters"),
+    confirmPassword: z.string(),
+  })
+  .refine((data) => data.password === data.confirmPassword, {
+    message: "Passwords do not match",
+    path: ["confirmPassword"],
+  });
+
+// Type exports
+export type SignInInput = z.infer<typeof signInSchema>;
+export type SignUpInput = z.infer<typeof signUpSchema>;
+export type ResetPasswordInput = z.infer<typeof resetPasswordSchema>;
+export type NewPasswordInput = z.infer<typeof newPasswordSchema>;

--- a/packages/validators/src/index.ts
+++ b/packages/validators/src/index.ts
@@ -6,3 +6,6 @@ export const unused = z.string().describe(
    with back and frontend, you can put them in here
   `,
 );
+
+// Export auth validators
+export * from "./auth";


### PR DESCRIPTION
## Summary
- Implemented server actions for authentication form submissions as part of the Supabase Auth migration
- Created validation schemas and error handling for auth operations
- Task #8 from the auth feature implementation

## Changes
- Added Zod validation schemas for auth forms (signIn, signUp, resetPassword) in `packages/validators/src/auth.ts`
- Created server actions file at `apps/nextjs/src/app/auth/actions.ts` with:
  - `signIn` action for email/password login
  - `signUp` action for user registration  
  - `resetPassword` action for password reset requests
  - `signInWithOAuth` for Google/Facebook OAuth
  - `signOut` action for logging out
- Implemented proper error handling for common scenarios:
  - Invalid credentials
  - Email already registered
  - Network errors
  - Email not confirmed
- Integrated with Supabase Auth API using the existing Supabase client configuration
- Followed existing server action patterns and code conventions from the codebase

## Test plan
- [ ] Test sign in with valid credentials
- [ ] Test sign in with invalid credentials
- [ ] Test sign up with new email
- [ ] Test sign up with existing email
- [ ] Test password reset flow
- [ ] Verify validation errors display correctly
- [ ] Test OAuth providers (Google, Facebook) when configured

## Related
- Part of auth feature implementation from task-master
- Task #8: Implement auth API handlers for form submissions